### PR TITLE
Update on ACDNet Documentation and Code Syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ Environmental sound classification on the edge: A pipeline for deep acoustic net
 ## A. Training and Compressing ACDNet
 
 #### A.1 Prerequisits
-1. Create `python 3.7+` development environment 
-2. Install `torch 1.7.1` or higher.
-2. Install `wavio 0.0.4` python library
-3. Install `wget` for downloading ESC-50 over HTTP
-4. Install `FFmpeg` for downsampling and upsampling audio recordings
+1. Create `python 3.7+` development environment.
+2. Install `torch`.
+2. Install `wavio`.
+3. Install `wget` for downloading ESC-50 over HTTP.
+4. Install `FFmpeg` for downsampling and upsampling audio recordings. 
+    * Installation of `FFmpeg` requires `sudo` permission. If `sudo` permission is not available, virtual environment (e.g. `miniconda` needs to be used). Do not use `pip` to install `FFmpeg`, as it will very likely raise errors.
 
 ##### Note
 * ACDNet is developed and tested in macOS environment. The forthcoming sections assumes that the above libraries/softwares are now installed.*
@@ -27,49 +28,50 @@ Environmental sound classification on the edge: A pipeline for deep acoustic net
 #### A.2 Dataset preparation
 1. Download/clone the repository.
 2. Go to the root of ACDNet directory using the terminal.
-3. To download and process ESC-50 dataset, run: ```python common/prepare_dataset.py```
-4. Prepare the validation data, run: ```python common/val_generator.py```
+3. To download and process ESC-50 dataset, run: ```python common/prepare_dataset.py```.
+4. Prepare the validation data, run: ```python common/val_generator.py```.
 
 *All the required data of ESC-50 for processing `44.1kHz` and `20kHz` are now ready at `datasets/esc50` directory*
 
 #### A.3 Training ACDNet (PyTorch)
-*There are pretrained models provided inside `torch/resources/pretrained_models` directory that can be used instead of training a new model. The model names are self explanatory. There are 5 pretrained ACDNet models validated on 5-folds (5-fold cross validation), 95% Weight pruned and retrained ACDNet model for hybrid pruning, ACDNet20 pruned and fine-tuned (not trained) and ACDNet-20 trained model*
+*There are pretrained models provided inside `torch/resources/pretrained_models` directory that can be used instead of training a new model. The model names are self explanatory. There are 5 pretrained ACDNet models validated on 5-folds (5-fold cross validation), 95% Weight pruned and retrained ACDNet model for hybrid pruning, ACDNet20 pruned and fine-tuned (not trained) and ACDNet-20 trained model*.
 
-However, to conduct the training of a brand new ACDNet, run: ```python torch/trainer.py```
+However, to conduct the training of a brand new ACDNet, run: ```python torch/trainer.py```.
 ##### Notes
-* Follow on-screen self-explanatory steps
+* Follow on-screen self-explanatory steps.
 * To train a brand new ACDNet, please select `training from scratch` option and keep the model path `empty` in the next step.
-* The trained models will be saved at `torch/trained_models directory`
+* The trained models will be saved at `torch/trained_models directory`.
 * The models will have names `YourGivenName_foldNo` on which it was validated.
-* For five fold cross validation, there will be 5 models named accordingly
+* For five fold cross validation, there will be 5 models named accordingly.
 
 #### A.4 Testing ACDNet (PyTorch)
-1. To test a trained model, run this command: ```python torch/tester.py```
-2. Follow the on-screen self explanatory steps
+1. To test a trained model, run this command: ```python torch/tester.py```.
+2. Follow the on-screen self explanatory steps.
 
 ##### Notes
 * A model should always be tested on the fold on which it was validated to reproduce the result.
 * For example, if a model was validated on fold-1, it will reproduce the validation accuracy on that fold. For all other folds (fold 2-5), it will produce approximately 100% prediction accuracy since it was trained on those folds.
 
 #### A.5 Pruning ACDNet (PyTorch)
-1. To conduct pruning run: ```python torch/pruning.py```
-2. Follow the on-screen self explanatory steps
+1. To conduct pruning run: ```python torch/pruning.py```.
+2. Follow the on-screen self explanatory steps.
+    * While giving the path of the trained model, make sure you give the full path, such as: `/home/<username>/path/to/the/model.pt`.
 
 ##### Notes
 * To conduct `hybrid` pruning on ACDNet, please run `weight pruning` on ACDNet first and then apply `hybrid pruning` on the weight pruned model.
 * The on-screen steps are easy enough to achieve this goal.
-* The pruned models will be stored inside `torch/pruned_models` directory
+* The pruned models will be stored inside `torch/pruned_models` directory.
 
 #### A.6 Re-Training ACDNet (PyTorch)
 To conduct retraining a pruned model, follow these steps:
-1. Run: ```python torch\trainer.py```
-2. Choose the training options
-3. Provide pruned model path
+1. Run: ```python torch/trainer.py```.
+2. Choose the training options.
+3. Provide pruned model path. Make sure to provide the full path, such as: `/home/<username>/path/to/the/model.pt`.
 4. Provide fold number for the model to be validated.
 
 #### A.7 Quantizing ACDNet (PyTorch)
-1. For 8-bit post training quantization, run: ```python torch/quanization.py```
-2. Provide model path.
+1. For 8-bit post training quantization, run: ```python torch/quantization.py``.`
+2. Provide model path. Make sure to provide the full path, such as: `/home/<username>/path/to/the/model.pt`.
 3. Provide the fold on which the model was validated.
 
 
@@ -77,14 +79,14 @@ To conduct retraining a pruned model, follow these steps:
 For deployment purpose we use Tensorflow and Tensorflow Lite.
 
 #### B.1 Prerequisist:
-1. Install tensorflow 2.2.0
+1. Install `tensorflow`.
 
 #### B.2 Training ACDNet-20
 *There is a pretrained ACDNet-20 model inside `tf/resources/pretrained_models` directory. This can be used instead.*
 
 To rebuild ACDNet-20 from scratch in TF, follow these steps:
 1. Run: ```python tf/trainer.py```
-2. Provide the ACDNet-20 PyTorch model path for it to retrieve the configuration of ACDNet-20 and build an equivalent TF model
+2. Provide the ACDNet-20 PyTorch model path for it to retrieve the configuration of ACDNet-20 and build an equivalent TF model.
 3. Follow the on-screen steps for finish the process.
 
 ##### Notes

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -70,7 +70,6 @@ This repository has the following git submodule dependencies
 
 | Dependency     | URL                                                   | Branch           | Path                                              | Comment                                              |
 | -------------- | ----------------------------------------------------- | ---------------- | ------------------------------------------------- | ---------------------------------------------------- |
-| TensorFlow     | https://github.com/tensorflow/tensorflow              | v2.3.1_transpose | ext/tensorflow                                    | Modified to support Transpose TFLite micro operation |
 | Flatbuffers    | https://github.com/google/flatbuffers.git             | v1.12.0          | ext/flatbuffers                                   |                                                      |
 | Spresense      | https://github.com/spresense/spresense.git            | v2.0.1           | ext/spresense                                     | Supports TFLite micro                                |
 | NuttX          | https://github.com/spresense/spresense-nuttx.git      |                  | ext/spresense/nuttx                               |                                                      |
@@ -78,12 +77,13 @@ This repository has the following git submodule dependencies
 | nnabla Runtime | https://github.com/sony/nnabla-c-runtime              |                  | ext/spresense/externals/nnablart/nnabla-c-runtime |                                                      |
 
 Additional python requirements, which are installed automatically, include:
-- h5py==2.10.0
-- numpy==1.18.5
-- requests==2.24.0
-- six==1.15.0
-- tensorflow==2.3.1
-- tensorflow-estimator==2.3.0
+- h5py
+- numpy
+- requests
+- six
+- tabulate
+- tensorflow
+- tensorflow-estimator
 
 During the build, further dependencies including source audio may be required.
 
@@ -113,34 +113,9 @@ pip install -r requirements.txt
 
 #### 1.3.2.1. TensorFlow setup
 
-Clone TensorFlow repository
-```bash
-(cd ext && git clone --branch=v2.3.1 --depth=1 --recurse-submodules https://github.com/tensorflow/tensorflow.git)
-```
+Update:
+When installing the latest version of `tensorflow`, the `tflite` library and micro library get automatically installed.
 
-Download the TFLite build dependencies
-
-```bash
-(cd ext/tensorflow && ./tensorflow/lite/tools/make/download_dependencies.sh)
-```
-
-Apply each TensorFlow patch
-
-```bash
-(cd ext/tensorflow && git apply --reject --whitespace=fix ext/patches/tensorflow/{filename}.patch)
-```
-
-Build the tflite library for the local OS
-
-```bash
-(cd ext/tensorflow && ./tensorflow/lite/tools/make/build_lib.sh)
-```
-
-Create the tflite micro library for the local OS
-
-```bash
-(cd ext/tensorflow && make -f tensorflow/lite/micro/tools/make/Makefile microlite)
-```
 
 #### 1.3.2.2. Spresense setup
 
@@ -202,11 +177,10 @@ ln -s tensorflow spresense/examples/tflite_micro/tensorflow
 
 ## 1.4. Conversion of models <a name="convert"></a>
 
-Execute the python script to automatically convert all models
+Execute the python script to automatically convert all models:
 
-```bash
-./convert_model.py {path/to/model.h5} {fold}
-```
+```python <path/to/convert_model.py> <path/to/h5_version_of_the_TF_model> --fold <fold_number>```
+
 
 *Where*
 - model.h5 is a valid pretrained Keras model

--- a/deployment/lib/opts.py
+++ b/deployment/lib/opts.py
@@ -7,7 +7,7 @@ def parse():
     parent_dir = os.path.join(os.getcwd(),'..','datasets')
 
     # General settings    
-    parser.add_argument('--data', default=f'{parent_dir}',  required=False);
+    parser.add_argument('--data', default='{}/datasets/'.format(os.getcwd()),  required=False);
     parser.add_argument('--dataset', required=False, default='esc50', choices=['esc50', 'frog']);
     parser.add_argument('--fold', required=False, default='5', choices=['1','2','3','4','5']);    
     parser.add_argument('--BC', default=True, action='store_true', help='BC learning');

--- a/deployment/lib/quantize.py
+++ b/deployment/lib/quantize.py
@@ -4,7 +4,7 @@ import numpy as np
 def quantize_int8(x, axis):
   '''Quantization into int8_t precision, operating on x along axis'''
 
-  scaling_factor_shape = tuple(np.append([len(x)],np.ones(x.ndim - 1, dtype = np.int)))
+  scaling_factor_shape = tuple(np.append([len(x)],np.ones(x.ndim - 1, dtype = int)))
   epsilon = 0.000000001
   x_scaling_factor = (2 * np.max(np.abs(x), axis) / 255) + epsilon
   x_scaling_factor = x_scaling_factor.reshape(scaling_factor_shape)
@@ -16,7 +16,7 @@ def quantize_int8(x, axis):
 def quantize_int16(x, axis):
   '''Quantization into int16_t precision, operating on x along axis'''
   
-  scaling_factor_shape = tuple(np.append([len(x)],np.ones(x.ndim - 1, dtype = np.int)))
+  scaling_factor_shape = tuple(np.append([len(x)],np.ones(x.ndim - 1, dtype = int)))
   epsilon = 0.00000000001
   x_scaling_factor = (2 * np.max(np.abs(x), axis) / 65535) + epsilon  
   x_scaling_factor = x_scaling_factor.reshape(scaling_factor_shape)  
@@ -28,7 +28,7 @@ def quantize_int16(x, axis):
 def quantize_uint8(x, axis):
   '''Quantization into uint8_t precision, operating on x along axis'''
   
-  scaling_factor_shape = tuple(np.append([len(x)],np.ones(x.ndim - 1, dtype = np.int)))
+  scaling_factor_shape = tuple(np.append([len(x)],np.ones(x.ndim - 1, dtype = int)))
   epsilon = 0.000000001
   x_scaling_factor = (2 * np.max(np.abs(x), axis) / 255) + epsilon  
   x_scaling_factor = x_scaling_factor.reshape(scaling_factor_shape)  
@@ -40,7 +40,7 @@ def quantize_uint8(x, axis):
 def quantize_float16(x, axis):
   '''Quantization into float16 precision, operating on x along axis'''
   
-  scaling_factor_shape = tuple(np.append([len(x)],np.ones(x.ndim - 1, dtype = np.int)))
+  scaling_factor_shape = tuple(np.append([len(x)],np.ones(x.ndim - 1, dtype = int)))
   epsilon = 0.000000001
   x_scaling_factor = (2 * np.max(np.abs(x), axis) / 2.0) + epsilon  
   x_scaling_factor = x_scaling_factor.reshape(scaling_factor_shape)  
@@ -52,7 +52,7 @@ def quantize_float16(x, axis):
 def quantize_float32(x, axis):
   '''Quantization into float32 precision, operating on x along axis'''
   
-  scaling_factor_shape = tuple(np.append([len(x)],np.ones(x.ndim - 1, dtype = np.int)))
+  scaling_factor_shape = tuple(np.append([len(x)],np.ones(x.ndim - 1, dtype = int)))
   epsilon = 0.000000001
   x_scaling_factor = (2 * np.max(np.abs(x), axis) / 2.0) + epsilon  
   x_scaling_factor = x_scaling_factor.reshape(scaling_factor_shape)  
@@ -72,7 +72,7 @@ def get_cast(dtype):
     print('Casting dataset to float16')
     return quantize_float16
 
-  if dtype == tf.int8 or dtype == np.int8 or dtype =='int8':
+  if dtype == tf.int8 or dtype == int8 or dtype =='int8':
     print('Casting dataset to int8')
     return quantize_int8
 
@@ -80,7 +80,7 @@ def get_cast(dtype):
     print('Casting dataset to uint8')
     return quantize_uint8
 
-  if dtype == tf.int16 or dtype == np.int16 or dtype =='int16':
+  if dtype == tf.int16 or dtype == int16 or dtype =='int16':
     print('Casting dataset to int16')
     return quantize_int16
 
@@ -89,7 +89,7 @@ def quantization_tests():
   test_x = np.array([[[[-0.3],[0.1],[0.0],[0.2]]],[[[0.4],[0.1],[0.0],[0.2]]], [[[0.4],[-0.4],[0.4],[-0.4]]], [[[0.0],[0.0],[0.0],[0.0]]]])
 
   quant_int8_actual= quantize_int8(test_x, axis = -2).flatten()
-  quant_int8_expect = np.array([-128, 42, 0, 84, 127, 31, 0, 63, 127, -128, 127, -128, 0, 0, 0, 0], dtype=np.int8)
+  quant_int8_expect = np.array([-128, 42, 0, 84, 127, 31, 0, 63, 127, -128, 127, -128, 0, 0, 0, 0], dtype=int)
   assert np.array_equal(quant_int8_actual,quant_int8_expect), "INT8 quantization failed"
 
   quant_uint8_actual= quantize_uint8(test_x, axis = -2).flatten()

--- a/tf/trainer.py
+++ b/tf/trainer.py
@@ -28,7 +28,7 @@ class Trainer:
         model.summary();
 
         loss = 'kullback_leibler_divergence';
-        optimizer = keras.optimizers.SGD(lr=self.opt.LR, decay=self.opt.weightDecay, momentum=self.opt.momentum, nesterov=True)
+        optimizer = keras.optimizers.SGD(learning_rate=self.opt.LR, weight_decay=self.opt.weightDecay, momentum=self.opt.momentum, nesterov=True)
 
         model.compile(loss=loss, optimizer=optimizer , metrics=['accuracy']);
 

--- a/torch/pruning/filter_pruning.py
+++ b/torch/pruning/filter_pruning.py
@@ -127,7 +127,7 @@ class PruningTrainer:
 
     def load_test_data(self):
         if(self.testX is None):
-            data = np.load(os.path.join(self.opt.data, self.opt.dataset, 'test_data_44khz/fold{}_test4000.npz'.format(self.opt.split)), allow_pickle=True);
+            data = np.load(os.path.join(self.opt.data, self.opt.dataset, 'test_data_20khz/fold{}_test4000.npz'.format(self.opt.split)), allow_pickle=True);
             self.testX = torch.tensor(np.moveaxis(data['x'], 3, 1)).to(self.opt.device);
             self.testY = torch.tensor(data['y']).to(self.opt.device);
 

--- a/torch/pruning/weight_pruning.py
+++ b/torch/pruning/weight_pruning.py
@@ -138,7 +138,7 @@ class PruningTrainer:
 
     def load_test_data(self):
         if(self.testX is None):
-            data = np.load(os.path.join(self.opt.data, self.opt.dataset, 'test_data_44khz/fold{}_test4000.npz'.format(self.opt.split)), allow_pickle=True);
+            data = np.load(os.path.join(self.opt.data, self.opt.dataset, 'test_data_20khz/fold{}_test4000.npz'.format(self.opt.split)), allow_pickle=True);
             self.testX = torch.tensor(np.moveaxis(data['x'], 3, 1)).to(self.device);
             self.testY = torch.tensor(data['y']).to(self.device).to(self.device);
 

--- a/torch/quantization.py
+++ b/torch/quantization.py
@@ -4,6 +4,7 @@ import glob;
 import math;
 import random;
 import torch;
+import numpy as np
 
 sys.path.append(os.getcwd());
 sys.path.append(os.path.join(os.getcwd(), 'common'));
@@ -19,7 +20,8 @@ class Trainer:
         self.testY = None;
         self.trainX = None;
         self.trainY = None;
-        self.opt.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu");
+        #self.opt.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu");
+        self.opt.device = torch.device("cpu")
         self.trainGen = train_generator.setup(self.opt, self.opt.split);
 
     def load_train_data(self):
@@ -32,7 +34,7 @@ class Trainer:
 
     def load_test_data(self):
         if(self.testX is None):
-            data = np.load(os.path.join(self.opt.data, self.opt.dataset, 'test_data_44khz/fold{}_test4000.npz'.format(self.opt.split)), allow_pickle=True);
+            data = np.load(os.path.join(self.opt.data, self.opt.dataset, 'test_data_20khz/fold{}_test4000.npz'.format(self.opt.split)), allow_pickle=True);
             self.testX = torch.tensor(np.moveaxis(data['x'], 3, 1)).to(self.opt.device);
             self.testY = torch.tensor(data['y']).to(self.opt.device);
 
@@ -140,7 +142,7 @@ class Trainer:
 
     def TestModel(self, quant=False):
         if quant:
-            net = torch.jit.load(self.opt.model_path)
+            net = torch.jit.load(os.getcwd() + '/torch/quantized_models/' + self.opt.model_name + '.pt')
         else:
             net = self.__load_model();
             calc.summary(net, (1,1,self.opt.inputLength));

--- a/torch/resources/models.py
+++ b/torch/resources/models.py
@@ -131,7 +131,7 @@ def GetACDNetModel(input_len=30225, nclass=50, sr=20000, channel_config=None):
 from torch.quantization import QuantStub, DeQuantStub
 class ACDNetQuant(nn.Module):
     def __init__(self, input_length, n_class, sr, ch_conf=None):
-        super(ACDNetV2, self).__init__();
+        super(ACDNetQuant, self).__init__();
         self.input_length = input_length;
         self.ch_config = ch_conf;
 


### PR DESCRIPTION
# Update on ACDNet Documentation and Code Syntax
The previous documentation and the codes for ACDNet training, testing and pruning had some bugs, which have been fixed in this version.

## ACDNet training and testing

*   The latest version of Python, Torch and Numpy has been installed.

*   Installation of ffpeg requires sudo permission. If sudo permission is not available, virtual environment (like miniconda needs to be used). Do not use pip to install ffmpeg.

*   Downloaded acdent-master from github.

*   The given instructions, until `python torch/tester.py`, works as expected. 



## ACDNet pruning with PyTorch

*   When running pruning.py, the following error occurs for all four pruning options:

        RuntimeError: mat1 and mat2 shapes cannot be multiplied (60x100 and 50x50)

    - To solve the problem, go to `torch/pruning/weight_pruning.py` and `torch/pruning/filter_pruning.py`, edit function `load_test_data(self)`, to change `test_data_44khz` to `test_data_20khz`.


*   During pruning, make sure you provide the full path of the model, such as: `/home/<username>/path/to/the/model.pt`


*   In the github documentation,

    - in section A.6 Re-Training ACDNet (PyTorch), step#1 uses an incorrect symbol ‘\’ to specify the path of trainer.py. Therefore, it has been be edited to “python torch/trainer.py”.

    - in section A.7 Quantizing ACDNet (PyTorch), the step#1’s file path is missing a ‘t’ making ‘quanization.py’, hence has been edited as: “python torch/quantization.py”


## ACDNet Quantization with PyTorch

*   When quantization.py is run, the following errors will appear with the present version:

        NameError: name 'np' is not defined

        RuntimeError: mat1 and mat2 shapes cannot be multiplied (1600x96 and 48x50)

        TypeError: super(type, obj): obj must be an instance or subtype of type

        RuntimeError: PytorchStreamReader failed reading zip archive: failed finding central directory



    - To solve these, 
        - Open the file quantization.py and insert the following line at the beginning of the file:

                import numpy as np

        - Go to torch/quantization.py, edit the function load_test_data(self), to change ‘test_data_44khz’ to ‘test_data_20khz’.

        - Go to torch/resources/models.py, edit line#134 to: `super(ACDNetQuant, self).__init__()`

        - Go to torch/quantization.py, edit function TestModel(self, quant=False) at line#143 to:

                net = torch.jit.load(os.getcwd() + '/torch/quantized_models/' + self.opt.model_name + '.pt')



*   One may also encounter the following error:

        RuntimeError: It looks like you are trying to quantize a CUDA tensor while QNNPACK backend is enabled. Although not expected to happen in practice, you might have done it for testing purposes. Please, either change the quantization engine or move the tensor to a CPU.

    - To solve this, edit line#23 in quantization.py to: `self.opt.device = torch.device("cpu");`




## ACDNet compression with Tensorflow

*   When running “python `tf/trainer.py`, the following warning appears:

        WARNING:absl:`lr` is deprecated in Keras optimizer, please use `learning_rate` or use the legacy optimizer, e.g.,tf.keras.optimizers.legacy.SGD.

    - And also the following error occurs:

        ValueError: decay is deprecated in the new Keras optimizer, please check the docstring for valid arguments, or use the legacy optimizer, e.g., tf.keras.optimizers.legacy.SGD.

    - To solve these,, edit line#31 in `tf/trainer.py` to change `lr` to `learning_rate` and `decay` to `weight_decay`. Therefore, line#31 should be: 

        optimizer = keras.optimizers.SGD(learning_rate=self.opt.LR, weight_decay=self.opt.weightDecay, momentum=self.opt.momentum, nesterov=True)


*   The following dependencies, required to deploy Tensorflow’s MCU version, have been installed with their latest versions:

    **h5py**  
    **numpy**  
    **requests**  
    **six**  
    **tensorflow**  
    **tensorflow-estimator** 


*   Installed `tabulate` using `pip`.

*   The following error appears:

        AttributeError: module 'numpy' has no attribute 'int'.

    - This can be solved by replacing all `np.int` and `int8` syntaxes with `int`, in the file: `acdnet-master/deployment/lib/quantize.py`

*   A FileNotFound error appears, which can be solved by editing line#10 of the file: `deployment/lib/opts.py`, as:

        parser.add_argument('--data', default='{}/datasets/'.format(os.getcwd()),  required=False);

    - This ensures the correct default path for ‘--data’.

*   Correct terminal command to run the TFLite converter:

        python {path/to/convert_model.py} {path/to/h5 version of the TF model} --fold {fold_number}

**Note that, the pushing of the converted tf model to MCU has not been intended in this update and hence no change has been made in the MCU part of the documentation.**
